### PR TITLE
fixes to ebR_QC2440A2_agg_curves-stats_b0.csv, ebR_QC2440A2_agg_curves-stats_r2.csv

### DIFF
--- a/ebRisk/output/QC/ebR_QC2440A2_agg_curves-stats_b0.csv
+++ b/ebRisk/output/QC/ebR_QC2440A2_agg_curves-stats_b0.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:16dc677792610cfeff0b9019bca8c2a25f3160a986891b98e3567c752d3f4f13
-size 1933386
+oid sha256:4dea762ce1e50b4e6b252233f7a485dec01acfe92893dc7a0fc0ec13c69ce0a3
+size 1931406

--- a/ebRisk/output/QC/ebR_QC2440A2_agg_curves-stats_r2.csv
+++ b/ebRisk/output/QC/ebR_QC2440A2_agg_curves-stats_r2.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0217438e29e1f05a051154ddf9cfafdbdd1d480f670c6c94ac45948590653e06
-size 1933386
+oid sha256:350ccd5a546f471a08d8bf4f1622407b377960b6f4a433b9a54d7afe3e0aaa93
+size 1931406


### PR DESCRIPTION
- fixes to conform with 'current' psra model.
- added missing 'stat' column, reordered fields to match all other regions agg_curve-stats
- removed erroneous records that contain *total* in fsauid, genocc, gentype columns