### PR TITLE
add missing **total** values into national psra canada tables

### DIFF
--- a/data/national/psra_canada_agg_loss.zip
+++ b/data/national/psra_canada_agg_loss.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01e00631443c122d68ab61edde365d093f8f262dc3d369f92ba77724d42eaeb3
-size 7785
+oid sha256:4247e73c2cee166fbcbe1791da652d322d2fa8c253c7eabb6478338425f2ba91
+size 8084

--- a/data/national/psra_canada_expected_loss.zip
+++ b/data/national/psra_canada_expected_loss.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ce9fccf35fc4031620dfbed9b8b5baf9b276595ac5c21c29d4ba2b626e5462d
-size 23424
+oid sha256:15ac36762f252aeb6b74af1d6a0c6bbdd96e3ee6d5a9c0c99074696ad188bcd0
+size 25029


### PR DESCRIPTION
2 updated geopackages (psra_canada_agg_loss, psra_canada_expected_loss) now include the missing **total** values from source tables. Implemented in model-factory v1.4.4 release.

Refer to issue for details
https://github.com/OpenDRR/model-factory/issues/146
